### PR TITLE
CC-26451 Backporting password reset improvements.

### DIFF
--- a/architecture-baseline.json
+++ b/architecture-baseline.json
@@ -1,26 +1,5 @@
 [
     {
-        "fileName": "src/Spryker/Zed/Customer/Communication/Form/AddressForm.php",
-        "description": "Method `Spryker\\Zed\\Customer\\Communication\\Form\\AddressForm::getBlockPrefix()` must have return type.",
-        "rule": "ExternalMethodExtensionReturnTypeRule",
-        "ruleset": "Spryker",
-        "priority": "1"
-    },
-    {
-        "fileName": "src/Spryker/Zed/Customer/Communication/Form/CustomerForm.php",
-        "description": "Method `Spryker\\Zed\\Customer\\Communication\\Form\\CustomerForm::getBlockPrefix()` must have return type.",
-        "rule": "ExternalMethodExtensionReturnTypeRule",
-        "ruleset": "Spryker",
-        "priority": "1"
-    },
-    {
-        "fileName": "src/Spryker/Zed/Customer/Communication/Form/CustomerUpdateForm.php",
-        "description": "Method `Spryker\\Zed\\Customer\\Communication\\Form\\CustomerUpdateForm::getBlockPrefix()` must have return type.",
-        "rule": "ExternalMethodExtensionReturnTypeRule",
-        "ruleset": "Spryker",
-        "priority": "1"
-    },
-    {
         "fileName": "src/Spryker/Zed/Customer/Dependency/Facade/CustomerToCountryBridge.php",
         "description": "Bridges: Method `getPreferredCountryByName()` must have `public function get<DomainEntity>Collection(<DomainEntity>CriteriaTransfer): <DomainEntity>CollectionTransfer` signature.",
         "rule": "BridgeFacadeMethodsRule",

--- a/src/Spryker/Zed/Customer/Business/Customer/Checker/PasswordResetExpirationChecker.php
+++ b/src/Spryker/Zed/Customer/Business/Customer/Checker/PasswordResetExpirationChecker.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Customer\Business\Customer\Checker;
+
+use DateTime;
+use Generated\Shared\Transfer\CustomerErrorTransfer;
+use Generated\Shared\Transfer\CustomerResponseTransfer;
+use Orm\Zed\Customer\Persistence\SpyCustomer;
+use Spryker\Zed\Customer\CustomerConfig;
+
+class PasswordResetExpirationChecker implements PasswordResetExpirationCheckerInterface
+{
+    /**
+     * @var \Spryker\Zed\Customer\CustomerConfig
+     */
+    protected CustomerConfig $customerConfig;
+
+    /**
+     * @param \Spryker\Zed\Customer\CustomerConfig $customerConfig
+     */
+    public function __construct(CustomerConfig $customerConfig)
+    {
+        $this->customerConfig = $customerConfig;
+    }
+
+    /**
+     * @param \Orm\Zed\Customer\Persistence\SpyCustomer$customerEntity
+     * @param \Generated\Shared\Transfer\CustomerResponseTransfer $customerResponseTransfer
+     *
+     * @return \Generated\Shared\Transfer\CustomerResponseTransfer
+     */
+    public function checkPasswordResetExpiration(
+        SpyCustomer $customerEntity,
+        CustomerResponseTransfer $customerResponseTransfer
+    ): CustomerResponseTransfer {
+        if (!$this->customerConfig->isCustomerPasswordResetExpirationEnabled()) {
+            return $customerResponseTransfer
+                ->setIsSuccess(true);
+        }
+
+        /** @var \DateTime|string|null $restorePasswordDate */
+        $restorePasswordDate = $customerEntity->getRestorePasswordDate();
+
+        if (!$restorePasswordDate) {
+            return $customerResponseTransfer;
+        }
+
+        if (is_string($restorePasswordDate)) {
+            $restorePasswordDate = new DateTime($restorePasswordDate);
+        }
+
+        $expirationDate = clone $restorePasswordDate;
+        $expirationDate->modify($this->customerConfig->getCustomerPasswordResetExpirationPeriod());
+        $now = new DateTime();
+
+        if ($now < $expirationDate) {
+            return $customerResponseTransfer;
+        }
+
+        $customerErrorTransfer = (new CustomerErrorTransfer())->setMessage(CustomerConfig::GLOSSARY_KEY_CONFIRM_EMAIL_LINK_INVALID_OR_USED);
+
+        return $customerResponseTransfer
+            ->setIsSuccess(false)
+            ->addError($customerErrorTransfer);
+    }
+}

--- a/src/Spryker/Zed/Customer/Business/Customer/Checker/PasswordResetExpirationCheckerInterface.php
+++ b/src/Spryker/Zed/Customer/Business/Customer/Checker/PasswordResetExpirationCheckerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Customer\Business\Customer\Checker;
+
+use Generated\Shared\Transfer\CustomerResponseTransfer;
+use Orm\Zed\Customer\Persistence\SpyCustomer;
+
+interface PasswordResetExpirationCheckerInterface
+{
+    /**
+     * @param \Orm\Zed\Customer\Persistence\SpyCustomer$customerEntity
+     * @param \Generated\Shared\Transfer\CustomerResponseTransfer $customerResponseTransfer
+     *
+     * @throws \RuntimeException
+     *
+     * @return \Generated\Shared\Transfer\CustomerResponseTransfer
+     */
+    public function checkPasswordResetExpiration(
+        SpyCustomer $customerEntity,
+        CustomerResponseTransfer $customerResponseTransfer
+    ): CustomerResponseTransfer;
+}

--- a/src/Spryker/Zed/Customer/Business/CustomerBusinessFactory.php
+++ b/src/Spryker/Zed/Customer/Business/CustomerBusinessFactory.php
@@ -14,6 +14,8 @@ use Spryker\Zed\Customer\Business\Checkout\CustomerOrderSaver;
 use Spryker\Zed\Customer\Business\Checkout\CustomerOrderSaverInterface;
 use Spryker\Zed\Customer\Business\Checkout\CustomerOrderSaverWithMultiShippingAddress;
 use Spryker\Zed\Customer\Business\Customer\Address;
+use Spryker\Zed\Customer\Business\Customer\Checker\PasswordResetExpirationChecker;
+use Spryker\Zed\Customer\Business\Customer\Checker\PasswordResetExpirationCheckerInterface;
 use Spryker\Zed\Customer\Business\Customer\Customer;
 use Spryker\Zed\Customer\Business\Customer\CustomerReader;
 use Spryker\Zed\Customer\Business\Customer\CustomerReaderInterface;
@@ -66,10 +68,21 @@ class CustomerBusinessFactory extends AbstractBusinessFactory
             $this->getLocaleFacade(),
             $this->createCustomerExpander(),
             $this->createCustomerPasswordPolicyValidator(),
+            $this->createPasswordResetExpirationChecker(),
             $this->getPostCustomerRegistrationPlugins(),
         );
 
         return $customer;
+    }
+
+    /**
+     * @return \Spryker\Zed\Customer\Business\Customer\Checker\PasswordResetExpirationCheckerInterface
+     */
+    public function createPasswordResetExpirationChecker(): PasswordResetExpirationCheckerInterface
+    {
+        return new PasswordResetExpirationChecker(
+            $this->getConfig(),
+        );
     }
 
     /**

--- a/src/Spryker/Zed/Customer/Communication/Form/AddressForm.php
+++ b/src/Spryker/Zed/Customer/Communication/Form/AddressForm.php
@@ -181,7 +181,7 @@ class AddressForm extends AbstractType
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $choices
+     * @param array<mixed, mixed> $choices
      *
      * @return $this
      */
@@ -331,8 +331,8 @@ class AddressForm extends AbstractType
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $choices
-     * @param array $preferredChoices
+     * @param array<mixed, mixed> $choices
+     * @param array<mixed, mixed> $preferredChoices
      *
      * @return $this
      */
@@ -444,7 +444,7 @@ class AddressForm extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'customer_address';
     }
@@ -454,7 +454,7 @@ class AddressForm extends AbstractType
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/Spryker/Zed/Customer/Communication/Form/CustomerForm.php
+++ b/src/Spryker/Zed/Customer/Communication/Form/CustomerForm.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
@@ -118,7 +119,7 @@ class CustomerForm extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'customer';
     }
@@ -188,7 +189,7 @@ class CustomerForm extends AbstractType
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $choices
+     * @param array<mixed, mixed> $choices
      *
      * @return $this
      */
@@ -246,7 +247,7 @@ class CustomerForm extends AbstractType
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $choices
+     * @param array<mixed, mixed> $choices
      *
      * @return $this
      */
@@ -319,7 +320,7 @@ class CustomerForm extends AbstractType
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $choices
+     * @param array<mixed, mixed> $choices
      *
      * @return $this
      */
@@ -351,7 +352,7 @@ class CustomerForm extends AbstractType
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $choices
+     * @param array<mixed, mixed> $choices
      *
      * @return $this
      */
@@ -394,9 +395,9 @@ class CustomerForm extends AbstractType
     }
 
     /**
-     * @return array
+     * @return list<\Symfony\Component\Validator\Constraint>
      */
-    protected function createEmailConstraints()
+    protected function createEmailConstraints(): array
     {
         $emailConstraints = [
             new NotBlank(),
@@ -456,7 +457,7 @@ class CustomerForm extends AbstractType
     /**
      * @return \Symfony\Component\Form\CallbackTransformer
      */
-    protected function createDateTimeModelTransformer()
+    protected function createDateTimeModelTransformer(): CallbackTransformer
     {
         return new CallbackTransformer(
             function ($dateAsString) {
@@ -473,7 +474,7 @@ class CustomerForm extends AbstractType
     /**
      * @return \Symfony\Component\Form\CallbackTransformer
      */
-    protected function createLocaleModelTransformer()
+    protected function createLocaleModelTransformer(): CallbackTransformer
     {
         return new CallbackTransformer(
             function ($localeAsObject) {
@@ -494,7 +495,7 @@ class CustomerForm extends AbstractType
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/Spryker/Zed/Customer/Communication/Form/CustomerUpdateForm.php
+++ b/src/Spryker/Zed/Customer/Communication/Form/CustomerUpdateForm.php
@@ -120,7 +120,7 @@ class CustomerUpdateForm extends CustomerForm
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $choices
+     * @param array<mixed, mixed> $choices
      *
      * @return $this
      */
@@ -138,7 +138,7 @@ class CustomerUpdateForm extends CustomerForm
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $choices
+     * @param array<mixed, mixed> $choices
      *
      * @return $this
      */
@@ -157,7 +157,7 @@ class CustomerUpdateForm extends CustomerForm
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'customer';
     }
@@ -167,7 +167,7 @@ class CustomerUpdateForm extends CustomerForm
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/Spryker/Zed/Customer/CustomerConfig.php
+++ b/src/Spryker/Zed/Customer/CustomerConfig.php
@@ -41,6 +41,11 @@ class CustomerConfig extends AbstractBundleConfig
     public const CUSTOMER_REGISTRATION_WITH_CONFIRMATION_MAIL_TYPE = 'customer registration confirmation mail';
 
     /**
+     * @var string
+     */
+    public const GLOSSARY_KEY_CONFIRM_EMAIL_LINK_INVALID_OR_USED = 'customer.error.confirm_email_link.invalid_or_used';
+
+    /**
      * Specification:
      * - Regular expression to validate Customer First Name field.
      *
@@ -98,6 +103,16 @@ class CustomerConfig extends AbstractBundleConfig
     protected const PASSWORD_RESTORE_TOKEN_URL_WITHOUT_STORE = '%s/password/restore?token=%s';
 
     /**
+     * @var string
+     */
+    protected const CUSTOMER_PASSWORD_EXPIRATION_PERIOD = '+2 hours';
+
+    /**
+     * @var bool
+     */
+    protected const PASSWORD_RESET_EXPIRATION_IS_ENABLED = false;
+
+    /**
      * @api
      *
      * @return string
@@ -105,6 +120,34 @@ class CustomerConfig extends AbstractBundleConfig
     public function getHostYves()
     {
         return $this->get(CustomerConstants::BASE_URL_YVES);
+    }
+
+    /**
+     * Specification:
+     * - Toggles the password reset expiration.
+     * - It is enabled by default.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function isCustomerPasswordResetExpirationEnabled(): bool
+    {
+        return static::PASSWORD_RESET_EXPIRATION_IS_ENABLED;
+    }
+
+    /**
+     * Specification:
+     * - Returns a time string that must be compatible with https://www.php.net/manual/en/datetime.modify.php that is used to check if the password reset has been expired.
+     * - The default is 2h hours.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getCustomerPasswordResetExpirationPeriod(): string
+    {
+        return static::CUSTOMER_PASSWORD_EXPIRATION_PERIOD;
     }
 
     /**

--- a/tests/SprykerTest/Zed/Customer/Business/Facade/RestorePasswordTest.php
+++ b/tests/SprykerTest/Zed/Customer/Business/Facade/RestorePasswordTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Zed\Customer\Business\Facade;
+
+use DateTime;
+use Generated\Shared\Transfer\CustomerTransfer;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Zed
+ * @group Customer
+ * @group Business
+ * @group Facade
+ * @group RestorePasswordTest
+ * Add your own group annotations below this line
+ */
+class RestorePasswordTest extends AbstractCustomerFacadeTest
+{
+    /**
+     * @var bool
+     */
+    protected const PASSWORD_VALIDATION_ON_RESTORE_PASSWORD_ENABLED = true;
+
+    /**
+     * @return void
+     */
+    public function testRestoringANonExpiredResetToken(): void
+    {
+        // Arrange
+        $customerTransfer = $this->tester->haveCustomer([
+            CustomerTransfer::RESTORE_PASSWORD_KEY => '7a96da42437d4b12a05bc48ca7c99548',
+            CustomerTransfer::RESTORE_PASSWORD_DATE => (new DateTime())->format('Y-m-d H:i:s'),
+            CustomerTransfer::PASSWORD => 'changeme123',
+        ]);
+
+        // Act
+        $customerResponseTransfer = $this->tester->getFacade()->restorePassword($customerTransfer);
+
+        // Assert
+        $this->assertTrue($customerResponseTransfer->getIsSuccess());
+        $this->assertCount(0, $customerResponseTransfer->getErrors());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRestoringAnExpiredResetTokenIsEnabled(): void
+    {
+        $this->tester->mockConfigMethod(
+            'isCustomerPasswordResetExpirationEnabled',
+            true,
+        );
+
+        // Arrange
+        $this->tester->mockConfigMethod(
+            'getCustomerPasswordResetExpirationPeriod',
+            '+2',
+        );
+
+        $customerTransfer = $this->tester->haveCustomer([
+            CustomerTransfer::RESTORE_PASSWORD_KEY => '51408d2551d148e78612b37d7d3fcbfc',
+            CustomerTransfer::RESTORE_PASSWORD_DATE => '2000-10-10 12:00:00',
+            CustomerTransfer::PASSWORD => 'changeme123',
+        ]);
+
+        // Act
+        $customerResponseTransfer = $this->tester->getFacade()->restorePassword($customerTransfer);
+
+        // Assert
+        $this->assertFalse($customerResponseTransfer->getIsSuccess());
+        $this->assertCount(1, $customerResponseTransfer->getErrors());
+        $this->assertEquals(
+            'customer.error.confirm_email_link.invalid_or_used',
+            $customerResponseTransfer->getErrors()[0]->getMessage(),
+        );
+    }
+
+    /**
+     * This test is the same as before but it disables the expiration check.
+     *
+     * @return void
+     */
+    public function testRestoringAnExpiredResetTokenIsDisabled(): void
+    {
+        // Arrange
+        $this->tester->mockConfigMethod(
+            'isCustomerPasswordResetExpirationEnabled',
+            false,
+        );
+
+        $customerTransfer = $this->tester->haveCustomer([
+            CustomerTransfer::RESTORE_PASSWORD_KEY => '51408d2551d148e78612b37d7d3fcbfc',
+            CustomerTransfer::RESTORE_PASSWORD_DATE => '2000-10-10 12:00:00',
+            CustomerTransfer::PASSWORD => 'changeme123',
+        ]);
+
+        // Act
+        $customerResponseTransfer = $this->tester->getFacade()->restorePassword($customerTransfer);
+
+        // Assert
+        $this->assertTrue($customerResponseTransfer->getIsSuccess());
+        $this->assertCount(0, $customerResponseTransfer->getErrors());
+    }
+
+    /**
+     * @uses \Spryker\Zed\Customer\CustomerConfig::isRestorePasswordValidationEnabled()
+     *
+     * @return void
+     */
+    public function testRestorePasswordValidatesPasswordWhenPasswordValidationEnabled(): void
+    {
+        // Arrange
+        $customerTransfer = $this->tester->createTestCustomerTransfer();
+        $this->tester->mockConfigMethod(
+            'isRestorePasswordValidationEnabled',
+            static::PASSWORD_VALIDATION_ON_RESTORE_PASSWORD_ENABLED,
+        );
+        $customerResponseTransfer = $this->tester->getFacade()->registerCustomer($customerTransfer);
+        $customerTransfer = $this->tester->getFacade()->confirmRegistration($customerResponseTransfer->getCustomerTransfer());
+        $this->tester->getFacade()->sendPasswordRestoreMail($customerTransfer);
+        $customerTransfer = $this->tester->getFacade()->getCustomer($customerTransfer);
+        $customerTransfer->setPassword(static::VALUE_SHORT_PASSWORD);
+
+        // Act
+        $customerResponseTransfer = $this->tester->getFacade()->restorePassword($customerTransfer);
+
+        // Assert
+        $this->assertFalse($customerResponseTransfer->getIsSuccess());
+        $this->assertTrue($this->hasMessageInCustomerResponseTransfer(
+            static::GLOSSARY_KEY_MIN_LENGTH_ERROR,
+            $customerResponseTransfer,
+        ));
+        $this->assertTrue($this->hasErrorInCustomerResponseTransfer(
+            static::GLOSSARY_KEY_MIN_LENGTH_ERROR,
+            $customerResponseTransfer,
+        ));
+    }
+}


### PR DESCRIPTION
Branch: backport/7.51.6
Ticket: https://spryker.atlassian.net/browse/CC-26461
Version: 7.51.6
- Strategy: minor

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Customer                | patch                 |                       |

-----------------------------------------

#### Module Customer

##### Change log

Improvements

- Adjusted `CustomerFacade::restorePassword()` with the behavior that customer password resets expire after two hours.
- Introduced `CustomerConfig::isCustomerPasswordResetExpirationEnabled()` to enable or disable the reset expiration. It is enabled by default.
- Introduced `CustomerConfig::getCustomerPasswordResetExpirationPeriod()` to get a DateTime-compatible string to define the expiration threshold.

